### PR TITLE
feat(input): Add form and basic input components

### DIFF
--- a/frontend/src/components/ui/BasicInput.tsx
+++ b/frontend/src/components/ui/BasicInput.tsx
@@ -1,0 +1,51 @@
+import React from 'react';
+import { cva } from 'class-variance-authority';
+
+interface BasicInputProps {
+  name: string;
+  label?: string;
+  disabled?: boolean;
+  className?: string;
+  placeholder?: string;
+  onChange?: (value: string) => void;
+}
+
+const inputStyles = cva(
+  'w-full px-3 py-2 border rounded-md shadow-sm focus:outline-none focus:ring-2',
+  {
+    variants: {
+      disabled: {
+        true: 'bg-gray-100 text-gray-500',
+        false: 'bg-white text-gray-900',
+      },
+    },
+    defaultVariants: {
+      disabled: false,
+    },
+  }
+);
+
+export const BasicInput: React.FC<BasicInputProps> = ({ name, label, disabled, className, placeholder, onChange }) => {
+  const handleChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    if (onChange) {
+      onChange(event.target.value);
+    }
+  };
+
+  return (
+    <div className="w-full">
+      {label && (
+        <label className="block text-sm font-medium text-gray-700 mb-1">
+          {label}
+        </label>
+      )}
+      <input
+        name={name}
+        className={inputStyles({ disabled }) + ` ${className}`}
+        disabled={disabled}
+        placeholder={placeholder}
+        onChange={handleChange}
+      />
+    </div>
+  );
+}; 

--- a/frontend/src/components/ui/FormInput.tsx
+++ b/frontend/src/components/ui/FormInput.tsx
@@ -1,0 +1,60 @@
+import React from 'react';
+import { useFormContext, Controller } from 'react-hook-form';
+import { cva } from 'class-variance-authority';
+
+interface FormInputProps {
+  name: string;
+  label?: string;
+  disabled?: boolean;
+  className?: string;
+  placeholder?: string;
+}
+
+const inputStyles = cva(
+  'w-full px-3 py-2 border rounded-md shadow-sm focus:outline-none focus:ring-2',
+  {
+    variants: {
+      error: {
+        true: 'border-red-500 focus:ring-red-500',
+        false: 'border-gray-300 focus:ring-blue-500',
+      },
+      disabled: {
+        true: 'bg-gray-100 text-gray-500',
+        false: 'bg-white text-gray-900',
+      },
+    },
+    defaultVariants: {
+      error: false,
+      disabled: false,
+    },
+  }
+);
+
+export const FormInput: React.FC<FormInputProps> = ({ name, label, disabled, className, placeholder }) => {
+  const { control, formState: { errors } } = useFormContext();
+
+  const errorMessage = errors[name]?.message as string | undefined;
+
+  return (
+    <div className="w-full">
+      {label && (
+        <label className="block text-sm font-medium text-gray-700 mb-1">
+          {label}
+        </label>
+      )}
+      <Controller
+        name={name}
+        control={control}
+        render={({ field }) => (
+          <input
+            {...field}
+            className={inputStyles({ error: !!errors[name], disabled }) + ` ${className}`}
+            disabled={disabled}
+            placeholder={placeholder}
+          />
+        )}
+      />
+      {errorMessage && <p className="mt-1 text-sm text-red-600">{errorMessage}</p>}
+    </div>
+  );
+}; 

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -17,15 +17,6 @@
   -moz-osx-font-smoothing: grayscale;
 }
 
-a {
-  font-weight: 500;
-  color: #646cff;
-  text-decoration: inherit;
-}
-a:hover {
-  color: #535bf2;
-}
-
 body {
   margin: 0;
   display: flex;
@@ -40,25 +31,3 @@ h1 {
   line-height: 1.1;
 }
 
-button {
-  border-radius: 8px;
-  border: 1px solid transparent;
-  padding: 0.6em 1.2em;
-  font-size: 1em;
-  font-weight: 500;
-  font-family: inherit;
-  cursor: pointer;
-  transition: border-color 0.25s;
-}
-button:hover {
-  border-color: #646cff;
-}
-button:focus,
-button:focus-visible {
-  outline: 4px auto -webkit-focus-ring-color;
-}
-
-input, select, textarea {
-  color: #333;
-  background-color: #fff;
-}


### PR DESCRIPTION
Implemented a reusable BasicInput and FormInput component.
<img width="433" alt="Screenshot 2025-02-26 at 12 03 13" src="https://github.com/user-attachments/assets/3a62daa3-c83c-42d3-b5db-d48b9f448c82" />
<img width="431" alt="Screenshot 2025-02-26 at 12 03 26" src="https://github.com/user-attachments/assets/27a0a10a-5bec-4063-a5e2-d7cb44c4d88a" />


